### PR TITLE
Specify net-http dependency to avoid constant init errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ end
 
 gem 'nokogiri'
 gem 'faraday'
+gem 'net-http'
 
 # Use Capistrano for deployment
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,9 +200,13 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     msgpack (1.4.4)
     mysql2 (0.5.3)
+    net-http (0.2.0)
+      net-protocol
+      uri
     net-imap (0.2.3)
       digest
       net-protocol
@@ -222,6 +226,9 @@ GEM
       timeout
     net-ssh (6.1.0)
     nio4r (2.5.8)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
@@ -356,6 +363,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.1.0)
+    uri (0.11.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -375,6 +383,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 
@@ -396,6 +405,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   mysql2
+  net-http
   nokogiri
   okcomputer
   parallel


### PR DESCRIPTION
This avoids the "already initialized constant" errors that
evidently result from faraday's dependencies requiring
two different versions of net-protocol. For discussion see:
https://github.com/ruby/net-imap/issues/16#issuecomment-803086765
