### PR TITLE
Use scss_lint rather than scss-lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,8 @@ group :development, :test do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
 
-  # scss-lint will test the scss files to enfoce styles
-  gem 'scss-lint', require: false
+  # scss_lint will test the scss files to enfoce styles
+  gem 'scss_lint', require: false
 
   gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,9 +315,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.38.0)
+    scss_lint (0.43.2)
       rainbow (~> 2.0)
-      sass (~> 3.4.1)
+      sass (~> 3.4.15)
     selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -375,6 +375,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -406,7 +407,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails (~> 5.0)
-  scss-lint
+  scss_lint
   selenium-webdriver
   simplecov
   sprockets-rails


### PR DESCRIPTION
Avoid the warning:
```
WARNING: `scss-lint` has been renamed to `scss_lint` to follow proper RubyGems naming conventions. Update your Gemfile or relevant install scripts to install `scss_lint`.
```