### PR TITLE
Correct library website staff directory URL

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -12,4 +12,4 @@ class LDAPCheck < OkComputer::Check
 end
 
 OkComputer::Registry.register 'ldap', LDAPCheck.new
-OkComputer::Registry.register 'http_libraries_url_check', OkComputer::HttpCheck.new(Settings.library.profile_url + 'subject-libraries')
+OkComputer::Registry.register 'http_libraries_url_check', OkComputer::HttpCheck.new(Settings.library.profile_url)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,5 @@
 library:
-  profile_url: 'https://library.stanford.edu/people/'
+  profile_url: 'https://library.stanford.edu/staff-directory'
 
 directory:
   org_code: JAAA


### PR DESCRIPTION
  I think this got lost between the library
  website migration and not sending the http
  check to nagios-prod