### PR TITLE
Configure Dependabot to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To keep us updated on things like: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/