### PR TITLE
Change ldapsearch option from -h to -H

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,4 +11,4 @@ directory:
     options: '-q -f /etc/keytabs/webauth.keytab -U'
     required: true
   ldapsearch:
-    options:  -h directory.stanford.edu -b cn=people,dc=stanford,dc=edu
+    options:  -H ldap://directory.stanford.edu -b cn=people,dc=stanford,dc=edu


### PR DESCRIPTION
This is needed because the recent OS update changed the version of ldapsearch and the `-h` option has been removed and replaced by`-H`